### PR TITLE
feat: #1 単一のログ内の各行にタイムスタンプをつける

### DIFF
--- a/pueue/src/client/cli.rs
+++ b/pueue/src/client/cli.rs
@@ -425,6 +425,10 @@ https://github.com/Nukesor/pueue/issues/350#issue-1359083118"
         /// Show the whole output.
         #[arg(short, long)]
         full: bool,
+
+        /// Add timestamps to each line of the log output.
+        #[arg(short, long)]
+        timestamps: bool,
     },
 
     /// Follow the output of a currently running task.
@@ -440,6 +444,10 @@ https://github.com/Nukesor/pueue/issues/350#issue-1359083118"
         /// Only print the last X lines of the output before following
         #[arg(short, long)]
         lines: Option<usize>,
+
+        /// Add timestamps to each line of the log output.
+        #[arg(short, long)]
+        timestamps: bool,
     },
 
     /// Wait until tasks are finished.

--- a/pueue/src/client/commands/add.rs
+++ b/pueue/src/client/commands/add.rs
@@ -103,7 +103,7 @@ pub async fn add_task(
     }
 
     if follow {
-        follow_cmd(client, settings, style, Some(task_id), None).await?;
+        follow_cmd(client, settings, style, Some(task_id), None, false).await?;
     }
 
     Ok(())

--- a/pueue/src/client/commands/log/json.rs
+++ b/pueue/src/client/commands/log/json.rs
@@ -110,10 +110,12 @@ fn get_remote_log(output_bytes: Option<Vec<u8>>, timestamps: bool) -> String {
 
 /// Add timestamps to each line of the given string content.
 fn add_timestamps_to_string(content: &str) -> String {
-    let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
     content
         .lines()
-        .map(|line| format!("[{}] {}", timestamp, line))
+        .map(|line| {
+            let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
+            format!("[{}] {}", timestamp, line)
+        })
         .collect::<Vec<_>>()
         .join("\n")
 }

--- a/pueue/src/client/commands/log/mod.rs
+++ b/pueue/src/client/commands/log/mod.rs
@@ -31,6 +31,7 @@ pub async fn print_logs(
     json: bool,
     lines: Option<usize>,
     full: bool,
+    timestamps: bool,
 ) -> Result<()> {
     let lines = determine_log_line_amount(full, &lines);
     let selection = selection_from_params(all, group.clone(), task_ids.clone());
@@ -52,7 +53,7 @@ pub async fn print_logs(
 
     // Return the server response in json representation.
     if json {
-        print_log_json(task_logs, &settings, lines);
+        print_log_json(task_logs, &settings, lines, timestamps);
         return Ok(());
     }
 
@@ -76,7 +77,7 @@ pub async fn print_logs(
     // Iterate over each task and print the respective log.
     let mut task_iter = task_logs.iter().peekable();
     while let Some((_, task_log)) = task_iter.next() {
-        print_log(task_log, style, &settings, lines);
+        print_log(task_log, style, &settings, lines, timestamps);
 
         // Add a newline if there is another task that's going to be printed.
         if let Some((_, task_log)) = task_iter.peek() {
@@ -124,6 +125,7 @@ fn print_log(
     style: &OutputStyle,
     settings: &Settings,
     lines: Option<usize>,
+    timestamps: bool,
 ) {
     let task = &message.task;
     // We only show logs of finished or running tasks.
@@ -137,9 +139,9 @@ fn print_log(
     print_task_info(task, style);
 
     if settings.client.read_local_logs {
-        print_local_log(message.task.id, style, settings, lines);
+        print_local_log(message.task.id, style, settings, lines, timestamps);
     } else if message.output.is_some() {
-        print_remote_log(message, style, lines);
+        print_remote_log(message, style, lines, timestamps);
     } else {
         println!("Logs requested from pueue daemon, but none received. Please report this bug.");
     }

--- a/pueue/src/client/commands/mod.rs
+++ b/pueue/src/client/commands/mod.rs
@@ -204,9 +204,11 @@ pub async fn handle_command(
             delay_until,
         } => enqueue(client, style, task_ids, group, all, delay_until).await,
         SubCommand::Env { cmd } => env(client, style, cmd).await,
-        SubCommand::Follow { task_id, lines } => {
-            follow(client, settings, style, task_id, lines).await
-        }
+        SubCommand::Follow {
+            task_id,
+            lines,
+            timestamps,
+        } => follow(client, settings, style, task_id, lines, timestamps).await,
         SubCommand::Group { cmd, json } => group(client, style, cmd, json).await,
         SubCommand::Kill {
             task_ids,
@@ -221,9 +223,10 @@ pub async fn handle_command(
             json,
             lines,
             full,
+            timestamps,
         } => {
             print_logs(
-                client, settings, style, task_ids, group, all, json, lines, full,
+                client, settings, style, task_ids, group, all, json, lines, full, timestamps,
             )
             .await
         }


### PR DESCRIPTION
## Summary
- log コマンドに --timestamps/-t オプションを追加し、ログの各行にタイムスタンプを表示
- follow コマンドに --timestamps/-t オプションを追加し、リアルタイム出力にタイムスタンプを表示
- ローカルログファイル読み込みとリモートログ（daemon経由）の両方に対応
- JSON出力でのタイムスタンプ対応も実装
- followコマンドでの大量ログ途中終了問題を修正

## Test plan
- [x] pueue log --timestamps でログにタイムスタンプが表示されることを確認
- [x] pueue follow --timestamps でリアルタイム出力にタイムスタンプが表示されることを確認
- [x] pueue log --timestamps --json でJSON形式出力にタイムスタンプが含まれることを確認
- [x] 大量ログでfollowが途中終了しないことを確認
- [x] ビルド・リント・フォーマットチェックが通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)